### PR TITLE
Use --clean instead of --rm-dist for goreleaser since it is deprecated

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
For goreleaser, use `--clean` instead of `--rm-dist`, which is deprecated option ([doc](https://goreleaser.com/deprecations/#-rm-dist)).