### PR TITLE
Rewrite goreleaser config to comply v2

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,4 @@
+version: 2
 before:
   hooks:
     - go mod tidy
@@ -15,14 +16,13 @@ builds:
       - windows
       - darwin
 archives:
-  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}'
-    replacements:
-      darwin: darwin
-      linux: linux
-      windows: windowns
-      386: i386
-      amd64: x86_64
+  - name_template: >-
+      {{- .ProjectName }}_
+      {{- .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 release:
   prerelease: auto


### PR DESCRIPTION
Fix goreleaser config to be up to date with version 2.
I run the workflow and confirmed it successfully releases binaries: https://github.com/ikanago/codeownerizer/releases