### PR TITLE
Show response headers for debugging rate limit

### DIFF
--- a/codeownerizer.go
+++ b/codeownerizer.go
@@ -15,16 +15,19 @@ const pushPermission = "push"
 
 func AddUngrantedOwners(ctx context.Context, api *github.Client, org string, repo string, owners []codeowners.Owner) error {
 	owners = uniqueOwners(owners)
+	log.Printf("owners: %v", owners)
 
 	teams, _, err := api.Repositories.ListTeams(ctx, org, repo, nil)
 	if err != nil {
 		return err
 	}
+	log.Printf("teams: %v", teams)
 
 	collaborators, _, err := api.Repositories.ListCollaborators(ctx, org, repo, nil)
 	if err != nil {
 		return err
 	}
+	log.Printf("collaborators: %v", collaborators)
 
 	for _, owner := range owners {
 		switch owner.Type {

--- a/codeownerizer.go
+++ b/codeownerizer.go
@@ -35,6 +35,7 @@ func AddUngrantedOwners(ctx context.Context, api *github.Client, org string, rep
 				resp, err := api.Teams.AddTeamRepoBySlug(ctx, org, teamOwnerName, org, repo, &github.TeamAddTeamRepoOptions{
 					Permission: pushPermission,
 				})
+				log.Println(resp.Response.Header)
 				if err != nil {
 					log.Println(err.Error())
 					continue
@@ -52,6 +53,7 @@ func AddUngrantedOwners(ctx context.Context, api *github.Client, org string, rep
 				_, resp, err := api.Repositories.AddCollaborator(ctx, org, repo, userOwnerName, &github.RepositoryAddCollaboratorOptions{
 					Permission: pushPermission,
 				})
+				log.Println(resp.Response.Header)
 				if err != nil {
 					log.Println(err.Error())
 					continue
@@ -65,6 +67,7 @@ func AddUngrantedOwners(ctx context.Context, api *github.Client, org string, rep
 		case codeowners.EmailOwner:
 			emailOwnerEmail := owner.String()
 			userSearchResult, resp, err := api.Search.Users(ctx, fmt.Sprintf("%s in:email", emailOwnerEmail), nil)
+			log.Println(resp.Response.Header)
 			if err != nil {
 				log.Println(err.Error())
 				continue


### PR DESCRIPTION
- For debugging rate limit on adding permissions to teams, show response headers when there are rate limits to know information about that
  - This is temporary fix; I'll rollback later