### PR TITLE
Reduce making unnecessary requests to avoid rate limit

### DIFF
--- a/codeownerizer.go
+++ b/codeownerizer.go
@@ -78,7 +78,7 @@ func AddUngrantedOwners(ctx context.Context, api *github.Client, org string, rep
 				continue
 			}
 
-			emailOwnerUsername := stringify(userSearchResult.Users[0].Name)
+			emailOwnerUsername := stringify(userSearchResult.Users[0].Login)
 
 			if !hasUserOwnerSufficientPermission(collaborators, emailOwnerUsername) || !containsUserOwner(collaborators, emailOwnerUsername) {
 				_, resp, err := api.Repositories.AddCollaborator(ctx, org, repo, emailOwnerUsername, &github.RepositoryAddCollaboratorOptions{

--- a/codeownerizer.go
+++ b/codeownerizer.go
@@ -16,12 +16,12 @@ const pushPermission = "push"
 func AddUngrantedOwners(ctx context.Context, api *github.Client, org string, repo string, owners []codeowners.Owner) error {
 	owners = uniqueOwners(owners)
 
-	teams, _, err := api.Repositories.ListTeams(ctx, org, repo, nil)
+	teams, err := ListTeams(ctx, api, org, repo)
 	if err != nil {
 		return err
 	}
 
-	collaborators, _, err := api.Repositories.ListCollaborators(ctx, org, repo, nil)
+	collaborators, err := ListCollaborators(ctx, api, org, repo)
 	if err != nil {
 		return err
 	}
@@ -31,6 +31,9 @@ func AddUngrantedOwners(ctx context.Context, api *github.Client, org string, rep
 		case codeowners.TeamOwner:
 			teamOwnerName := strings.Split(owner.String(), "/")[1]
 
+			// Grant a push permission to
+			// - a team that is already have an access to the repository but does not have a push permission.
+			// - a team that does not have an access to the repository.
 			if !hasTeamOwnerSufficientPermission(teams, teamOwnerName) || !containsTeamOwner(teams, teamOwnerName) {
 				resp, err := api.Teams.AddTeamRepoBySlug(ctx, org, teamOwnerName, org, repo, &github.TeamAddTeamRepoOptions{
 					Permission: pushPermission,
@@ -101,4 +104,40 @@ func AddUngrantedOwners(ctx context.Context, api *github.Client, org string, rep
 	}
 
 	return nil
+}
+
+func ListTeams(ctx context.Context, api *github.Client, org string, repo string) ([]*github.Team, error) {
+	allTeams := []*github.Team{}
+	opts := &github.ListOptions{PerPage: 100}
+	for {
+		teams, resp, err := api.Repositories.ListTeams(ctx, org, repo, opts)
+		if err != nil {
+			return nil, err
+		}
+		allTeams = append(allTeams, teams...)
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return allTeams, nil
+}
+
+func ListCollaborators(ctx context.Context, api *github.Client, org string, repo string) ([]*github.User, error) {
+	allCollaborators := []*github.User{}
+	opts := &github.ListCollaboratorsOptions{
+		ListOptions: github.ListOptions{PerPage: 100},
+	}
+	for {
+		collaborators, resp, err := api.Repositories.ListCollaborators(ctx, org, repo, opts)
+		if err != nil {
+			return nil, err
+		}
+		allCollaborators = append(allCollaborators, collaborators...)
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return allCollaborators, nil
 }

--- a/codeownerizer_test.go
+++ b/codeownerizer_test.go
@@ -46,7 +46,8 @@ func TestAddUngrantedOwnersWithTeamOwner(t *testing.T) {
 		mock.WithRequestMatch(
 			mock.GetReposTeamsByOwnerByRepo,
 			[]github.Team{
-				// Code owner exists in the organization and has push permission
+				// Code owner exists in the repository and has push permission.
+				// No need to add this team to the repository.
 				{
 					Name: github.Ptr("octocats"),
 					Slug: github.Ptr("octocats"),
@@ -54,7 +55,8 @@ func TestAddUngrantedOwnersWithTeamOwner(t *testing.T) {
 						"push": true,
 					},
 				},
-				// Code owner exists in the organization and does not have push permission
+				// Code owner exists in the organization and does not have push permission.
+				// Need to add this team to the repository.
 				{
 					Name: github.Ptr("Octocats Admins"),
 					Slug: github.Ptr("octocats-admins"),
@@ -62,7 +64,8 @@ func TestAddUngrantedOwnersWithTeamOwner(t *testing.T) {
 						"push": false,
 					},
 				},
-				// Code owner does not exist in the organization
+				// Code owner does not exist in the organization.
+				// Need to add this team to the repository.
 				// {
 				// 	Name: github.Ptr("Octocats Viewers"),
 				// 	Slug: github.Ptr("octocats-viewers"),
@@ -160,21 +163,24 @@ func TestAddUngrantedOwnersWithUserOwner(t *testing.T) {
 		mock.WithRequestMatch(
 			mock.GetReposCollaboratorsByOwnerByRepo,
 			[]github.User{
-				// Code owner exists in the organization and has push permission
+				// Code owner exists in the repository and has push permission.
+				// No need to add this user to the repository.
 				{
 					Login: github.Ptr("octocat"),
 					Permissions: map[string]bool{
 						"push": true,
 					},
 				},
-				// Code owner exists in the organization and does not have push permission
+				// Code owner exists in the repository and does not have push permission.
+				// Need to add this user to the repository.
 				{
 					Login: github.Ptr("doctocat"),
 					Permissions: map[string]bool{
 						"push": false,
 					},
 				},
-				// Code owner does not exist in the organization
+				// Code owner does not exist in the repository.
+				// Need to add this user to the repository.
 				// {
 				// 	Login: github.Ptr("octocat2"),
 				// },
@@ -267,21 +273,24 @@ func TestAddUngrantedOwnersWithEmailOwner(t *testing.T) {
 		mock.WithRequestMatch(
 			mock.GetReposCollaboratorsByOwnerByRepo,
 			[]github.User{
-				// Code owner exists in the organization and has push permission
+				// Code owner exists in the repository and has push permission.
+				// No need to add this user to the repository.
 				{
 					Login: github.Ptr("octocat"),
 					Permissions: map[string]bool{
 						"push": true,
 					},
 				},
-				// Code owner exists in the organization and does not have push permission
+				// Code owner exists in the repository and does not have push permission.
+				// Need to add this user to the repository.
 				{
 					Login: github.Ptr("doctocat"),
 					Permissions: map[string]bool{
 						"push": false,
 					},
 				},
-				// Code owner does not exist in the organization
+				// Code owner does not exist in the repository.
+				// Need to add this user to the repository.
 				// {
 				// 	Login: github.Ptr("octocat2"),
 				// },

--- a/codeownerizer_test.go
+++ b/codeownerizer_test.go
@@ -13,6 +13,354 @@ import (
 	"github.com/migueleliasweb/go-github-mock/src/mock"
 )
 
+func TestAddUngrantedOwnersWithTeamOwner(t *testing.T) {
+	org := "org"
+	repo := "repo"
+
+	ruleset, err := codeowners.LoadFile("testdata/CODEOWNERS-TEAM")
+	if err != nil {
+		t.Error(err)
+	}
+	var owners []codeowners.Owner
+	for _, rule := range ruleset {
+		owners = append(owners, rule.Owners...)
+	}
+
+	octocatsTeamAddedToRepo := false
+	putOrgsTeamsReposByOrgByTeamSlugByOwnerByRepoWithOctocatsTeam := mock.EndpointPattern{
+		Pattern: fmt.Sprintf("/orgs/%s/teams/%s/repos/%s/%s", org, "octocats", org, repo),
+		Method:  "PUT",
+	}
+	octocatsAdminsTeamAddedToRepo := false
+	putOrgsTeamsReposByOrgByTeamSlugByOwnerByRepoWithOctocatsAdminsTeam := mock.EndpointPattern{
+		Pattern: fmt.Sprintf("/orgs/%s/teams/%s/repos/%s/%s", org, "octocats-admins", org, repo),
+		Method:  "PUT",
+	}
+	octocatsViewersTeamAddedToRepo := false
+	putOrgsTeamsReposByOrgByTeamSlugByOwnerByRepoWithOctocatsViewersTeam := mock.EndpointPattern{
+		Pattern: fmt.Sprintf("/orgs/%s/teams/%s/repos/%s/%s", org, "octocats-viewers", org, repo),
+		Method:  "PUT",
+	}
+
+	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetReposTeamsByOwnerByRepo,
+			[]github.Team{
+				// Code owner exists in the organization and has push permission
+				{
+					Name: github.Ptr("octocats"),
+					Slug: github.Ptr("octocats"),
+					Permissions: map[string]bool{
+						"push": true,
+					},
+				},
+				// Code owner exists in the organization and does not have push permission
+				{
+					Name: github.Ptr("Octocats Admins"),
+					Slug: github.Ptr("octocats-admins"),
+					Permissions: map[string]bool{
+						"push": false,
+					},
+				},
+				// Code owner does not exist in the organization
+				// {
+				// 	Name: github.Ptr("Octocats Viewers"),
+				// 	Slug: github.Ptr("octocats-viewers"),
+				// },
+			},
+		),
+		mock.WithRequestMatch(
+			mock.GetReposCollaboratorsByOwnerByRepo,
+			[]github.User{},
+		),
+		mock.WithRequestMatchHandler(
+			putOrgsTeamsReposByOrgByTeamSlugByOwnerByRepoWithOctocatsTeam,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				octocatsTeamAddedToRepo = true
+			}),
+		),
+		mock.WithRequestMatchHandler(
+			putOrgsTeamsReposByOrgByTeamSlugByOwnerByRepoWithOctocatsAdminsTeam,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				octocatsAdminsTeamAddedToRepo = true
+			}),
+		),
+		mock.WithRequestMatchHandler(
+			putOrgsTeamsReposByOrgByTeamSlugByOwnerByRepoWithOctocatsViewersTeam,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				octocatsViewersTeamAddedToRepo = true
+			}),
+		),
+	)
+
+	client := github.NewClient(mockedHTTPClient)
+	ctx := context.Background()
+	err = AddUngrantedOwners(ctx, client, "org", "repo", owners)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if octocatsTeamAddedToRepo {
+		t.Errorf(
+			"expected %s %s not to be called\n",
+			putOrgsTeamsReposByOrgByTeamSlugByOwnerByRepoWithOctocatsTeam.Method,
+			putOrgsTeamsReposByOrgByTeamSlugByOwnerByRepoWithOctocatsTeam.Pattern,
+		)
+	}
+	if !octocatsAdminsTeamAddedToRepo {
+		t.Errorf(
+			"expected %s %s to be called\n",
+			putOrgsTeamsReposByOrgByTeamSlugByOwnerByRepoWithOctocatsAdminsTeam.Method,
+			putOrgsTeamsReposByOrgByTeamSlugByOwnerByRepoWithOctocatsAdminsTeam.Pattern,
+		)
+	}
+	if !octocatsViewersTeamAddedToRepo {
+		t.Errorf(
+			"expected %s %s to be called\n",
+			putOrgsTeamsReposByOrgByTeamSlugByOwnerByRepoWithOctocatsViewersTeam.Method,
+			putOrgsTeamsReposByOrgByTeamSlugByOwnerByRepoWithOctocatsViewersTeam.Pattern,
+		)
+	}
+}
+
+func TestAddUngrantedOwnersWithUserOwner(t *testing.T) {
+	org := "org"
+	repo := "repo"
+
+	ruleset, err := codeowners.LoadFile("testdata/CODEOWNERS-USER")
+	if err != nil {
+		t.Error(err)
+	}
+	var owners []codeowners.Owner
+	for _, rule := range ruleset {
+		owners = append(owners, rule.Owners...)
+	}
+
+	octocatAddedToRepo := false
+	putReposCollaboratorsByOwnerByRepoWithOctocat := mock.EndpointPattern{
+		Pattern: fmt.Sprintf("/repos/%s/%s/collaborators/%s", org, repo, "octocat"),
+		Method:  "PUT",
+	}
+	doctocatAddedToRepo := false
+	putReposCollaboratorsByOwnerByRepoWithDoctocat := mock.EndpointPattern{
+		Pattern: fmt.Sprintf("/repos/%s/%s/collaborators/%s", org, repo, "doctocat"),
+		Method:  "PUT",
+	}
+	octocat2AddedToRepo := false
+	putReposCollaboratorsByOwnerByRepoWithOctocat2 := mock.EndpointPattern{
+		Pattern: fmt.Sprintf("/repos/%s/%s/collaborators/%s", org, repo, "octocat2"),
+		Method:  "PUT",
+	}
+
+	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetReposTeamsByOwnerByRepo,
+			[]github.Team{},
+		),
+		mock.WithRequestMatch(
+			mock.GetReposCollaboratorsByOwnerByRepo,
+			[]github.User{
+				// Code owner exists in the organization and has push permission
+				{
+					Login: github.Ptr("octocat"),
+					Permissions: map[string]bool{
+						"push": true,
+					},
+				},
+				// Code owner exists in the organization and does not have push permission
+				{
+					Login: github.Ptr("doctocat"),
+					Permissions: map[string]bool{
+						"push": false,
+					},
+				},
+				// Code owner does not exist in the organization
+				// {
+				// 	Login: github.Ptr("octocat2"),
+				// },
+			},
+		),
+		mock.WithRequestMatchHandler(
+			putReposCollaboratorsByOwnerByRepoWithOctocat,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				octocatAddedToRepo = true
+			}),
+		),
+		mock.WithRequestMatchHandler(
+			putReposCollaboratorsByOwnerByRepoWithDoctocat,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				doctocatAddedToRepo = true
+			}),
+		),
+		mock.WithRequestMatchHandler(
+			putReposCollaboratorsByOwnerByRepoWithOctocat2,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				octocat2AddedToRepo = true
+			}),
+		),
+	)
+
+	client := github.NewClient(mockedHTTPClient)
+	ctx := context.Background()
+	err = AddUngrantedOwners(ctx, client, "org", "repo", owners)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if octocatAddedToRepo {
+		t.Errorf(
+			"expected %s %s not to be called\n",
+			putReposCollaboratorsByOwnerByRepoWithOctocat.Method,
+			putReposCollaboratorsByOwnerByRepoWithOctocat.Pattern,
+		)
+	}
+	if !doctocatAddedToRepo {
+		t.Errorf(
+			"expected %s %s to be called\n",
+			putReposCollaboratorsByOwnerByRepoWithDoctocat.Method,
+			putReposCollaboratorsByOwnerByRepoWithDoctocat.Pattern,
+		)
+	}
+	if !octocat2AddedToRepo {
+		t.Errorf(
+			"expected %s %s to be called\n",
+			putReposCollaboratorsByOwnerByRepoWithOctocat2.Method,
+			putReposCollaboratorsByOwnerByRepoWithOctocat2.Pattern,
+		)
+	}
+}
+
+func TestAddUngrantedOwnersWithEmailOwner(t *testing.T) {
+	org := "org"
+	repo := "repo"
+
+	ruleset, err := codeowners.LoadFile("testdata/CODEOWNERS-EMAIL")
+	if err != nil {
+		t.Error(err)
+	}
+	var owners []codeowners.Owner
+	for _, rule := range ruleset {
+		owners = append(owners, rule.Owners...)
+	}
+
+	octocatAddedToRepo := false
+	putReposCollaboratorsByOwnerByRepoWithOctocat := mock.EndpointPattern{
+		Pattern: fmt.Sprintf("/repos/%s/%s/collaborators/%s", org, repo, "octocat"),
+		Method:  "PUT",
+	}
+	doctocatAddedToRepo := false
+	putReposCollaboratorsByOwnerByRepoWithDoctocat := mock.EndpointPattern{
+		Pattern: fmt.Sprintf("/repos/%s/%s/collaborators/%s", org, repo, "doctocat"),
+		Method:  "PUT",
+	}
+	octocat2AddedToRepo := false
+	putReposCollaboratorsByOwnerByRepoWithOctocat2 := mock.EndpointPattern{
+		Pattern: fmt.Sprintf("/repos/%s/%s/collaborators/%s", org, repo, "octocat2"),
+		Method:  "PUT",
+	}
+
+	mockedHTTPClient := mock.NewMockedHTTPClient(
+		mock.WithRequestMatch(
+			mock.GetReposTeamsByOwnerByRepo,
+			[]github.Team{},
+		),
+		mock.WithRequestMatch(
+			mock.GetReposCollaboratorsByOwnerByRepo,
+			[]github.User{
+				// Code owner exists in the organization and has push permission
+				{
+					Login: github.Ptr("octocat"),
+					Permissions: map[string]bool{
+						"push": true,
+					},
+				},
+				// Code owner exists in the organization and does not have push permission
+				{
+					Login: github.Ptr("doctocat"),
+					Permissions: map[string]bool{
+						"push": false,
+					},
+				},
+				// Code owner does not exist in the organization
+				// {
+				// 	Login: github.Ptr("octocat2"),
+				// },
+			},
+		),
+		mock.WithRequestMatchHandler(
+			putReposCollaboratorsByOwnerByRepoWithOctocat,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				octocatAddedToRepo = true
+			}),
+		),
+		mock.WithRequestMatchHandler(
+			putReposCollaboratorsByOwnerByRepoWithDoctocat,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				doctocatAddedToRepo = true
+			}),
+		),
+		mock.WithRequestMatchHandler(
+			putReposCollaboratorsByOwnerByRepoWithOctocat2,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				octocat2AddedToRepo = true
+			}),
+		),
+		mock.WithRequestMatchHandler(
+			mock.GetSearchUsers,
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				q := r.URL.Query()["q"]
+				email := ""
+				if len(q) > 0 {
+					switch q[0] {
+					case "octocat@example.com in:email":
+						email = "octocat"
+					case "doctocat@example.com in:email":
+						email = "doctocat"
+					case "octocat2@example.com in:email":
+						email = "octocat2"
+					}
+				}
+				_, _ = w.Write(mock.MustMarshal(github.UsersSearchResult{
+					Users: []*github.User{
+						{
+							Login: github.Ptr(email),
+						},
+					},
+				}))
+			}),
+		),
+	)
+
+	client := github.NewClient(mockedHTTPClient)
+	ctx := context.Background()
+	err = AddUngrantedOwners(ctx, client, "org", "repo", owners)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if octocatAddedToRepo {
+		t.Errorf(
+			"expected %s %s not to be called\n",
+			putReposCollaboratorsByOwnerByRepoWithOctocat.Method,
+			putReposCollaboratorsByOwnerByRepoWithOctocat.Pattern,
+		)
+	}
+	if !doctocatAddedToRepo {
+		t.Errorf(
+			"expected %s %s to be called\n",
+			putReposCollaboratorsByOwnerByRepoWithDoctocat.Method,
+			putReposCollaboratorsByOwnerByRepoWithDoctocat.Pattern,
+		)
+	}
+	if !octocat2AddedToRepo {
+		t.Errorf(
+			"expected %s %s to be called\n",
+			putReposCollaboratorsByOwnerByRepoWithOctocat2.Method,
+			putReposCollaboratorsByOwnerByRepoWithOctocat2.Pattern,
+		)
+	}
+}
+
 func TestAddUngrantedOwners(t *testing.T) {
 	org := "org"
 	repo := "repo"
@@ -145,7 +493,7 @@ func TestAddUngrantedOwners(t *testing.T) {
 				_, _ = w.Write(mock.MustMarshal(github.UsersSearchResult{
 					Users: []*github.User{
 						{
-							Name: github.Ptr("email-owner"),
+							Login: github.Ptr("email-owner"),
 						},
 					},
 				}))

--- a/helpers.go
+++ b/helpers.go
@@ -20,7 +20,7 @@ func uniqueOwners(owners []codeowners.Owner) []codeowners.Owner {
 
 func hasTeamOwnerSufficientPermission(teams []*github.Team, name string) bool {
 	for _, team := range teams {
-		if (stringify(team.Name) == name) && !team.Permissions[pushPermission] {
+		if (stringify(team.Slug) == name) && !team.Permissions[pushPermission] {
 			return false
 		}
 	}
@@ -29,7 +29,7 @@ func hasTeamOwnerSufficientPermission(teams []*github.Team, name string) bool {
 
 func hasUserOwnerSufficientPermission(collaborators []*github.User, name string) bool {
 	for _, collaborator := range collaborators {
-		if (stringify(collaborator.Name) == name) && !collaborator.Permissions[pushPermission] {
+		if (stringify(collaborator.Login) == name) && !collaborator.Permissions[pushPermission] {
 			return false
 		}
 	}

--- a/helpers.go
+++ b/helpers.go
@@ -18,36 +18,36 @@ func uniqueOwners(owners []codeowners.Owner) []codeowners.Owner {
 	return unique
 }
 
-func hasTeamOwnerSufficientPermission(teams []*github.Team, name string) bool {
+func hasTeamOwnerSufficientPermission(teams []*github.Team, owner string) bool {
 	for _, team := range teams {
-		if (stringify(team.Slug) == name) && !team.Permissions[pushPermission] {
-			return false
-		}
-	}
-	return true
-}
-
-func hasUserOwnerSufficientPermission(collaborators []*github.User, name string) bool {
-	for _, collaborator := range collaborators {
-		if (stringify(collaborator.Login) == name) && !collaborator.Permissions[pushPermission] {
-			return false
-		}
-	}
-	return true
-}
-
-func containsTeamOwner(s []*github.Team, e string) bool {
-	for _, v := range s {
-		if e == stringify(v.Name) {
+		if (stringify(team.Slug) == owner) && team.Permissions[pushPermission] {
 			return true
 		}
 	}
 	return false
 }
 
-func containsUserOwner(s []*github.User, e string) bool {
-	for _, u := range s {
-		if e == stringify(u.Name) {
+func hasUserOwnerSufficientPermission(collaborators []*github.User, owner string) bool {
+	for _, collaborator := range collaborators {
+		if (stringify(collaborator.Login) == owner) && collaborator.Permissions[pushPermission] {
+			return true
+		}
+	}
+	return false
+}
+
+func containsTeamOwner(teams []*github.Team, owner string) bool {
+	for _, team := range teams {
+		if stringify(team.Slug) == owner {
+			return true
+		}
+	}
+	return false
+}
+
+func containsUserOwner(collaborators []*github.User, owner string) bool {
+	for _, collaborator := range collaborators {
+		if stringify(collaborator.Login) == owner {
 			return true
 		}
 	}

--- a/testdata/CODEOWNERS
+++ b/testdata/CODEOWNERS
@@ -24,6 +24,8 @@
 # the octocats team in the octo-org organization owns all .txt files.
 *.txt @octo-org/octocats
 
+* @octo-org/octocats-admins
+
 # In this example, @doctocat owns any files in the build/logs
 # directory at the root of the repository and any of its
 # subdirectories.

--- a/testdata/CODEOWNERS-EMAIL
+++ b/testdata/CODEOWNERS-EMAIL
@@ -1,0 +1,3 @@
+* octocat@example.com
+* doctocat@example.com
+* octocat2@example.com

--- a/testdata/CODEOWNERS-TEAM
+++ b/testdata/CODEOWNERS-TEAM
@@ -1,0 +1,3 @@
+* @octo-org/octocats
+* @octo-org/octocats-admins
+* @octo-org/octocats-viewers

--- a/testdata/CODEOWNERS-USER
+++ b/testdata/CODEOWNERS-USER
@@ -1,0 +1,3 @@
+* @octocat
+* @doctocat
+* @octocat2


### PR DESCRIPTION
## Background
- Encounters rate limit
  - It makes too many requests to grant a push permission for teams in a short period of time
  - Almost all the requests are redundant because they are already have the permission

## Fix
- Use `github.Team.Slug` instead of `Name` to compare with `owner`
	- `Slug` is a canonical id like `"service-platform-admins"`
	- `Name` can be a human-readable name like `"Service Platform Admins"`
	- Some team uses the different string for `Slug` and `Name`
		- `stringify(team.Name) == owner` unexpectedly returns `false` where team is a struct returned from GitHub API and `owner` is a team name in CODEOWNER
	- This leads that the following condition is always `true` and to make unnecessary requests
```golang
if !hasTeamOwnerSufficientPermission(teams, teamOwnerName) || !containsTeamOwner(teams, teamOwnerName) {
```

## Additional updates
- Implement functions `ListTeams` and `ListCollaborators` to handle pagination of API response
- Add tests for each owner kind: team, collaborator, and email

## Results
- This fix reduces unnecessary requests in our repository